### PR TITLE
fix: typo in gem name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem 'sinatra-advanced-routes'
 gem 'rubocop'
 gem 'omniauth-openid'
 gem 'omniauth-openid-connect', git: 'https://github.com/jjbohn/omniauth-openid-connect'
-gem 'restclient'
+gem 'rest-client'
 


### PR DESCRIPTION
`bundle` throw this error otherwise 

```
extconf.rb:2:in `<main>': This failure is intentional. You probably meant to install and run rest-client (RuntimeError)
This failure is intentional. You probably meant to install and run rest-client
```